### PR TITLE
Fix AttributeError on First return

### DIFF
--- a/dirsync/run.py
+++ b/dirsync/run.py
@@ -28,8 +28,9 @@ def from_cmdline():
     user_cfg_file = os.path.expanduser(USER_CFG_FILE)
     if not os.path.isfile(user_cfg_file):
         print('Creating user config file "%s" ...' % user_cfg_file, end=''),
-        f = open(user_cfg_file, 'w').write(DEFAULT_USER_CFG)
-        f.close()
+        with open(user_cfg_file, 'w') as handle:
+            handle.write(DEFAULT_USER_CFG)
+
         print(' Done')
 
     try:


### PR DESCRIPTION
When I ran dirsync for the first time I encountered the following
error, because there was an attempt to close a None object. The
result of calling write on a file is None.

```
dirsync -h
Creating user config file "/Users/aquilabdullah/.dirsync" ...Traceback (most recent call last):
  File "/Users/aquilabdullah/.virtualenvs/dirsync/bin/dirsync", line 11, in <module>
    load_entry_point('dirsync', 'console_scripts', 'dirsync')()
  File "/Users/aquilabdullah/devel/python/dirsync/dirsync/run.py", line 32, in from_cmdline
    f.close()
AttributeError: 'NoneType' object has no attribute 'close'
```