### PR TITLE
fix(syncer): make symlinks always be treated as files

### DIFF
--- a/dirsync/syncer.py
+++ b/dirsync/syncer.py
@@ -249,11 +249,14 @@ class Syncer(object):
         # Files & directories only in source directory
         for f1 in self._dcmp.left_only:
             try:
-                st = os.stat(os.path.join(self._dir1, f1))
+                st = os.lstat(os.path.join(self._dir1, f1))
             except os.error:
                 continue
 
-            if stat.S_ISREG(st.st_mode):
+            if (
+                stat.S_ISREG(st.st_mode)
+                or stat.S_ISLNK(st.st_mode)
+            ):
                 if copyfunc:
                     copyfunc(f1, self._dir1, self._dir2)
                     self._added.append(os.path.join(self._dir2, f1))

--- a/tests/sync.py
+++ b/tests/sync.py
@@ -36,6 +36,16 @@ class SyncTestsFromSrc(DirSyncTestCase):
         self.assertEqual(file1.read(), 'modifying file')
         file1.close()
 
+    def test_sync_dir_link(self):
+        os.mkdir('src/dir0')
+        os.symlink('src/dir0', 'src/dir0a')
+        os.symlink('src/dir0a', 'src/dir0b')
+        sync('src', 'dst', 'sync',
+             create=True)
+        self.assertIsDir('dst/dir0')
+        self.assertTrue(os.path.islink('dst/dir0a'))
+        self.assertTrue(os.path.islink('dst/dir0b'))
+
 
 class SyncTestsWithDest(DirSyncTestCase):
 


### PR DESCRIPTION
For issue #35.
