### PR TITLE
fix(syncer): [issue #42] Remove redundant path slices in file paths and ancestor root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # buildout files and folders
 bin
 .installed.cfg
+eggs
 
 # tox directory
 .tox

--- a/dirsync/syncer.py
+++ b/dirsync/syncer.py
@@ -158,9 +158,9 @@ class Syncer(object):
 
                 if add_path:
                     left.add(path)
-                    anc_dirs = re_path[:-1].split('/')
+                    anc_dirs = re_path.split('/')
                     anc_dirs_path = ''
-                    for ad in anc_dirs[1:]:
+                    for ad in anc_dirs:
                         anc_dirs_path = os.path.join(anc_dirs_path, ad)
                         left.add(anc_dirs_path)
 


### PR DESCRIPTION
Removes possibly redundant path and ancestor root slicing as mentioned in #42.

Test results:
Before
![image](https://user-images.githubusercontent.com/57045366/141658893-d0092157-68c2-4bae-8d20-987a6b9fd9ff.png)

After
![image](https://user-images.githubusercontent.com/57045366/141658899-186446ca-9617-45b2-a58f-497492a683a8.png)
